### PR TITLE
Fix build error for llvm 3.6 and later

### DIFF
--- a/lib/llvmgen/llvm_helper.cpp
+++ b/lib/llvmgen/llvm_helper.cpp
@@ -53,5 +53,9 @@ LLVMTargetRef HelperLookupTarget(const char *triple, char **err) {
 }
 
 void HelperSetAsmVerbosity(LLVMTargetMachineRef tm, LLVMBool v) {
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 6)
+    reinterpret_cast<TargetMachine*>(tm)->Options.MCOptions.AsmVerbose = v;
+#else
     reinterpret_cast<TargetMachine*>(tm)->setAsmVerbosityDefault(v);
+#endif
 }


### PR DESCRIPTION
‘class llvm::TargetMachine’ has no member named ‘setAsmVerbosityDefault’