### PR TITLE
Update for LLVM opaque-pointer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(blissc VERSION 0.3.90)
+project(blissc VERSION 0.4.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
@@ -10,7 +10,7 @@ find_package(Python3 COMPONENTS Interpreter)
 include_directories(${blissc_BINARY_DIR}/include ${CMAKE_SOURCE_DIR}/include)
 
 if(NOT MSVC)
-  add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wpedantic $<$<CONFIG:DEBUG>:-Werror> $<$<CONFIG:DEBUG>:-Wno-error=deprecated-declarations>)
+  add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wpedantic $<$<CONFIG:DEBUG>:-Werror>)
 endif()
 
 add_library(libdriver STATIC lib/driver/driver.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,13 @@ project(blissc VERSION 0.3.90)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package(LLVM 12.0 REQUIRED)
+find_package(LLVM 14.0 REQUIRED)
 find_package(Python3 COMPONENTS Interpreter)
 
 include_directories(${blissc_BINARY_DIR}/include ${CMAKE_SOURCE_DIR}/include)
 
 if(NOT MSVC)
-  add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wpedantic $<$<CONFIG:DEBUG>:-Werror>)
+  add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wpedantic $<$<CONFIG:DEBUG>:-Werror> $<$<CONFIG:DEBUG>:-Wno-error=deprecated-declarations>)
 endif()
 
 add_library(libdriver STATIC lib/driver/driver.c)

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ of machine-specific support.
 ## Prerequisites
 
 * Recent-vintage C compiler
-* Recent version LLVM
+* Recent version LLVM (one that has support for opaque pointers)
 * CMake 3.13 or later, or a recent version of autotools
 
 Recent development and testing has been on Ubuntu 22.04 with
-gcc 11 and LLVM 12.0.
+gcc 11 and LLVM 15.0.
 
 ## Building the compiler
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,19 +1,19 @@
 dnl ++
 dnl  configure.ac - autoconf script for blissc
 dnl
-dnl  Copyright (c) 2013-2020, Matthew Madison.
+dnl  Copyright (c) 2013-2024, Matthew Madison.
 dnl  All rights reserved.
 dnl
 dnl  Distributed under license.  See LICENSE.TXT for details.
 dnl --
 
-AC_INIT([blissc], [0.3.0], [http://github.com/madisongh/blissc/issues])
+AC_INIT([blissc], [0.4.0], [http://github.com/madisongh/blissc/issues])
 AC_DEFINE([BLISSC_VERSION_MAJOR], [0], [Major version of blissc])
-AC_DEFINE([BLISSC_VERSION_MINOR], [3], [Minor version of blissc])
+AC_DEFINE([BLISSC_VERSION_MINOR], [4], [Minor version of blissc])
 AC_DEFINE([BLISSC_VERSION_MAINT], [0], [Maintenance level of blissc])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
-AC_COPYRIGHT([Copyright (c) 2013-2020, Matthew Madison])
+AC_COPYRIGHT([Copyright (c) 2013-2024, Matthew Madison])
 
 AC_PREREQ(2.69)
 

--- a/lib/llvmgen/llvm_builtins_x86.c
+++ b/lib/llvmgen/llvm_builtins_x86.c
@@ -204,10 +204,10 @@ gen_asminstr (gencodectx_t gctx, void *fctx, expr_node_t *exp, LLVMTypeRef neede
     i += 1;
     }
     if (LLVMGetTypeKind(asmp->rettype) == LLVMVoidTypeKind) {
-        LLVMBuildCall(gctx->curfn->builder, asmp->asminstr, argvals, asmp->argcount, "");
+        LLVMBuildCall2(gctx->curfn->builder, asmp->functype, asmp->asminstr, argvals, asmp->argcount, "");
         result = (neededtype == 0 ? 0 : LLVMConstNull(neededtype));
     } else {
-        result = LLVMBuildCall(gctx->curfn->builder, asmp->asminstr, argvals,
+        result = LLVMBuildCall2(gctx->curfn->builder, asmp->functype, asmp->asminstr, argvals,
                                asmp->argcount, llvmgen_temp(gctx));
         result = llvmgen_adjustval(gctx, result, neededtype, 0);
     }
@@ -339,10 +339,10 @@ llvmgen_asminstr (gencodectx_t gctx, const char *name, LLVMValueRef *arg, unsign
     i += 1;
     }
     if (LLVMGetTypeKind(asmp->rettype) == LLVMVoidTypeKind) {
-        LLVMBuildCall(gctx->curfn->builder, asmp->asminstr, argvals, asmp->argcount, "");
+        LLVMBuildCall2(gctx->curfn->builder, asmp->functype, asmp->asminstr, argvals, asmp->argcount, "");
         result = 0;
     } else {
-        result = LLVMBuildCall(gctx->curfn->builder, asmp->asminstr, argvals,
+        result = LLVMBuildCall2(gctx->curfn->builder, asmp->functype, asmp->asminstr, argvals,
                                asmp->argcount, llvmgen_temp(gctx));
     }
 

--- a/lib/llvmgen/llvm_ctrlexpgen.c
+++ b/lib/llvmgen/llvm_ctrlexpgen.c
@@ -413,7 +413,7 @@ gen_incr_decr_loop (gencodectx_t gctx, expr_node_t *exp, LLVMTypeRef neededtype)
     optype_t compareop = expr_idloop_cmptype(exp);
     LLVMValueRef neg1 = LLVMConstAllOnes(gctx->fullwordtype);
     LLVMValueRef zero = LLVMConstNull(gctx->fullwordtype);
-    LLVMValueRef loopidx = llvmgen_segaddress(gctx, expr_idloop_index(exp), 0, 0);
+    LLVMValueRef loopidx = llvmgen_segaddress(gctx, expr_idloop_index(exp), 0, 0, 0);
     int addrsigned = machine_addr_signed(gctx->mach);
     LLVMValueRef initval, endval, stepval, testphi, cmpval, result;
     LLVMBasicBlockRef loopblk, testblk, curblk;

--- a/lib/llvmgen/llvm_ctrlexpgen.c
+++ b/lib/llvmgen/llvm_ctrlexpgen.c
@@ -460,7 +460,7 @@ gen_incr_decr_loop (gencodectx_t gctx, expr_node_t *exp, LLVMTypeRef neededtype)
     llvmgen_expression(gctx, expr_idloop_body(exp), 0);
     if (LLVMGetBasicBlockTerminator(LLVMGetInsertBlock(builder)) == 0) {
         LLVMValueRef v;
-        v = LLVMBuildLoad(builder, loopidx, llvmgen_temp(gctx));
+        v = LLVMBuildLoad2(builder, gctx->fullwordtype, loopidx, llvmgen_temp(gctx));
         if (is_decr) {
             v = LLVMBuildSub(builder, v, stepval, llvmgen_temp(gctx));
         } else {

--- a/lib/llvmgen/llvm_execfuncgen.c
+++ b/lib/llvmgen/llvm_execfuncgen.c
@@ -273,9 +273,9 @@ gen_ch_pointer (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef need
             if (expr_litval(arg) != 0) {
                 offset = LLVMConstInt(gctx->fullwordtype, (unsigned long long int) expr_litval(arg), 0);
                 if (LLVMIsConstant(result)) {
-                    result = LLVMConstGEP(offset, &offset, 1);
+                    result = LLVMConstGEP2(gctx->unittype, offset, &offset, 1);
                 } else {
-                    result = LLVMBuildGEP(builder, result, &offset, 1, llvmgen_temp(gctx));
+                    result = LLVMBuildGEP2(builder, gctx->unittype, result, &offset, 1, llvmgen_temp(gctx));
                 }
             }
         } else {
@@ -305,7 +305,7 @@ gen_ch_rchar (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef needed
 
     arg = exprseq_head(args);
     addr = llvmgen_expression(gctx, arg, gctx->unitptrtype);
-    result = LLVMBuildLoad(builder, addr, llvmgen_temp(gctx));
+    result = LLVMBuildLoad2(builder, gctx->unittype, addr, llvmgen_temp(gctx));
 
     return llvmgen_adjustval(gctx, result, neededtype, 0);
 
@@ -328,15 +328,15 @@ gen_ch_rchar_a (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef need
 
     arg = exprseq_head(args);
     addraddr = llvmgen_expression(gctx, arg, LLVMPointerType(gctx->unitptrtype, 0));
-    addr = LLVMBuildLoad(builder, addraddr, llvmgen_temp(gctx));
+    addr = LLVMBuildLoad2(builder, gctx->unitptrtype, addraddr, llvmgen_temp(gctx));
     if (!postincrement) {
-        LLVMValueRef tmp = LLVMBuildGEP(builder, addr, &one, 1, llvmgen_temp(gctx));
+        LLVMValueRef tmp = LLVMBuildGEP2(builder, gctx->unittype, addr, &one, 1, llvmgen_temp(gctx));
         LLVMBuildStore(builder, tmp, addraddr);
         addr = tmp;
     }
-    result = LLVMBuildLoad(builder, addr, llvmgen_temp(gctx));
+    result = LLVMBuildLoad2(builder, gctx->unittype, addr, llvmgen_temp(gctx));
     if (postincrement) {
-        LLVMValueRef tmp = LLVMBuildGEP(builder, addr, &one, 1, llvmgen_temp(gctx));
+        LLVMValueRef tmp = LLVMBuildGEP2(builder, gctx->unittype, addr, &one, 1, llvmgen_temp(gctx));
         LLVMBuildStore(builder, tmp, addraddr);
     }
 
@@ -390,15 +390,15 @@ gen_ch_wchar_a (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef need
     ch = llvmgen_expression(gctx, arg, LLVMInt8TypeInContext(gctx->llvmctx));
     arg = arg->tq_next;
     addraddr = llvmgen_expression(gctx, arg, LLVMPointerType(gctx->unitptrtype, 0));
-    addr = LLVMBuildLoad(builder, addraddr, llvmgen_temp(gctx));
+    addr = LLVMBuildLoad2(builder, gctx->unittype, addraddr, llvmgen_temp(gctx));
     if (!postincrement) {
-        LLVMValueRef tmp = LLVMBuildGEP(builder, addr, &one, 1, llvmgen_temp(gctx));
+        LLVMValueRef tmp = LLVMBuildGEP2(builder, gctx->unittype, addr, &one, 1, llvmgen_temp(gctx));
         LLVMBuildStore(builder, tmp, addraddr);
         addr = tmp;
     }
     LLVMBuildStore(builder, ch, addr);
     if (postincrement) {
-        LLVMValueRef tmp = LLVMBuildGEP(builder, addr, &one, 1, llvmgen_temp(gctx));
+        LLVMValueRef tmp = LLVMBuildGEP2(builder, gctx->unittype, addr, &one, 1, llvmgen_temp(gctx));
         LLVMBuildStore(builder, tmp, addraddr);
     }
 
@@ -499,14 +499,14 @@ gen_ch_compare (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef need
 
     LLVMPositionBuilderAtEnd(builder, str2longer);
     argvals[0] = LLVMBuildSub(builder, len2, bound, llvmgen_temp(gctx));
-    argvals[1] = LLVMBuildGEP(builder, ptr2, &bound, 1, llvmgen_temp(gctx));
+    argvals[1] = LLVMBuildGEP2(builder, gctx->unittype, ptr2, &bound, 1, llvmgen_temp(gctx));
     argvals[2] = fill;
     result = llvmgen_asminstr(gctx, "SCASB_CMP", argvals, 3);
     llvmgen_btrack_update(gctx, bt, result);
 
     LLVMPositionBuilderAtEnd(builder, str1longer);
     argvals[0] = LLVMBuildSub(builder, len1, bound, llvmgen_temp(gctx));
-    argvals[1] = LLVMBuildGEP(builder, ptr1, &bound, 1, llvmgen_temp(gctx));
+    argvals[1] = LLVMBuildGEP2(builder, gctx->unittype, ptr1, &bound, 1, llvmgen_temp(gctx));
     argvals[2] = fill;
     result = llvmgen_asminstr(gctx, "SCASB_CMP", argvals, 3);
     llvmgen_btrack_update(gctx, bt, result);
@@ -610,7 +610,7 @@ gen_ch_findsub (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef need
     plen = llvmgen_expression(gctx, arg, gctx->fullwordtype);
     arg = arg->tq_next;
     pptr = llvmgen_expression(gctx, arg, gctx->unitptrtype);
-    pfirst = LLVMBuildLoad(builder, pptr, llvmgen_temp(gctx));
+    pfirst = LLVMBuildLoad2(builder, gctx->unittype, pptr, llvmgen_temp(gctx));
 
     test = LLVMBuildIsNull(builder, plen, llvmgen_temp(gctx));
     curblk = LLVMGetInsertBlock(builder);
@@ -658,7 +658,7 @@ gen_ch_findsub (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef need
     llvmgen_btrack_update_brcount(gctx, bt);
 
     LLVMPositionBuilderAtEnd(builder, updblk);
-    v = LLVMBuildGEP(builder, result, &one, 1, llvmgen_temp(gctx));
+    v = LLVMBuildGEP2(builder, gctx->unittype, result, &one, 1, llvmgen_temp(gctx));
     LLVMAddIncoming(curptr, &v, &updblk, 1);
     v = LLVMBuildSub(builder, remain, one, llvmgen_temp(gctx));
     LLVMAddIncoming(curlen, &v, &updblk, 1);
@@ -806,11 +806,11 @@ gen_ch_translate (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef ne
     LLVMBuildCondBr(builder, test, postloop, loopbody);
 
     LLVMPositionBuilderAtEnd(builder, loopbody);
-    sptr = LLVMBuildGEP(builder, sptr, &offphi, 1, llvmgen_temp(gctx));
-    chr = LLVMBuildLoad(builder, sptr, llvmgen_temp(gctx));
-    v = LLVMBuildGEP(builder, transtab, &chr, 1, llvmgen_temp(gctx));
-    chr = LLVMBuildLoad(builder, v, llvmgen_temp(gctx));
-    v = LLVMBuildGEP(builder, dptr, &offphi, 1, llvmgen_temp(gctx));
+    sptr = LLVMBuildGEP2(builder, gctx->unittype, sptr, &offphi, 1, llvmgen_temp(gctx));
+    chr = LLVMBuildLoad2(builder, gctx->unittype, sptr, llvmgen_temp(gctx));
+    v = LLVMBuildGEP2(builder, gctx->unittype, transtab, &chr, 1, llvmgen_temp(gctx));
+    chr = LLVMBuildLoad2(builder, gctx->unittype, v, llvmgen_temp(gctx));
+    v = LLVMBuildGEP2(builder, gctx->unittype, dptr, &offphi, 1, llvmgen_temp(gctx));
     LLVMBuildStore(builder, chr, v);
     v = LLVMBuildSub(builder, loopphi, one, llvmgen_temp(gctx));
     LLVMAddIncoming(loopphi, &v, &loopbody, 1);
@@ -819,7 +819,7 @@ gen_ch_translate (gencodectx_t gctx, void *ctx, expr_node_t *exp, LLVMTypeRef ne
     LLVMBuildBr(builder, loopblk);
 
     LLVMPositionBuilderAtEnd(builder, postloop);
-    dptr = LLVMBuildGEP(builder, dptr, &loopcount, 1, llvmgen_temp(gctx));
+    dptr = LLVMBuildGEP2(builder, gctx->unittype, dptr, &loopcount, 1, llvmgen_temp(gctx));
     test = LLVMBuildICmp(builder, LLVMIntULT, loopcount, dlen, llvmgen_temp(gctx));
     LLVMBuildCondBr(builder, test, fillblk, exitblk);
     llvmgen_btrack_update_phi(gctx, bt, LLVMGetInsertBlock(builder), dptr);

--- a/lib/llvmgen/llvm_expgen.c
+++ b/lib/llvmgen/llvm_expgen.c
@@ -112,7 +112,7 @@ llvmgen_addr_expression (gencodectx_t gctx, expr_node_t *exp,
         long off = expr_seg_offset(base);
         llvm_stgclass_t valclass;
         unsigned int sflags;
-        addr = llvmgen_segaddress(gctx, expr_seg_name(base), &valclass, &sflags);
+        addr = llvmgen_segaddress(gctx, expr_seg_name(base), &valclass, &sflags, 0);
         if (valclass == LLVM_REG && accinfo == 0 &&
             (sflags & (LLVMGEN_M_SEG_DEREFED|LLVMGEN_M_SEG_ISBIND)) == 0) {
             // XXX

--- a/lib/llvmgen/llvm_expgen.c
+++ b/lib/llvmgen/llvm_expgen.c
@@ -296,9 +296,7 @@ gen_routine_call (gencodectx_t gctx, expr_node_t *exp, LLVMTypeRef neededtype)
 
     if (expr_type(rtnexp) == EXPTYPE_PRIM_SEG &&
         name_type(expr_seg_name(rtnexp)) == LEXTYPE_NAME_ROUTINE) {
-        rtnadr = LLVMGetNamedFunction(gctx->module, name_azstring(expr_seg_name(rtnexp)));
-        type = LLVMGetElementType(LLVMTypeOf(rtnadr));
-        rettype = LLVMGetReturnType(type);
+        rtnadr = llvmgen_rtntype_info(gctx, expr_seg_name(rtnexp), &type, &rettype);
         formalcount = LLVMCountParamTypes(type);
     } else {
         rettype = gctx->fullwordtype;

--- a/lib/llvmgen/llvm_gencode.c
+++ b/lib/llvmgen/llvm_gencode.c
@@ -446,6 +446,7 @@ gencode_init (void *ectx, logctx_t logctx, machinedef_t *mach, symctx_t symctx)
     gctx->llvmctx = gctx->mctx->llvmctx;
     gctx->int1type = LLVMIntTypeInContext(gctx->llvmctx, 1);
     gctx->fullwordtype = LLVMIntTypeInContext(gctx->llvmctx, machine_scalar_bits(mach));
+    gctx->unittype = LLVMIntTypeInContext(gctx->llvmctx, machine_unit_bits(mach));
     gctx->unitptrtype = LLVMPointerType(LLVMIntTypeInContext(gctx->llvmctx,
                                                              machine_unit_bits(mach)), 0);
     gctx->intptrtszype = LLVMIntTypeInContext(gctx->llvmctx, machine_addr_bits(mach));

--- a/lib/llvmgen/llvm_helper.cpp
+++ b/lib/llvmgen/llvm_helper.cpp
@@ -18,7 +18,11 @@
 #include "llvm_helper.h"
 #include "llvm/IR/Instructions.h"
 
+#if LLVM_VERSION_MAJOR >= 14
+#include "llvm/MC/TargetRegistry.h"
+#else
 #include "llvm/Support/TargetRegistry.h"
+#endif
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/Host.h"
 

--- a/lib/llvmgen/llvm_opexpgen.c
+++ b/lib/llvmgen/llvm_opexpgen.c
@@ -104,7 +104,7 @@ llvmgen_assignment (gencodectx_t gctx, expr_node_t *lhs, expr_node_t *rhs)
         v = LLVMBuildShl(builder, srcmask, accinfo.posval, llvmgen_temp(gctx));
         v = llvmgen_adjustval(gctx, v, lhstype, 0);
         dstmask = LLVMBuildNot(builder, v, llvmgen_temp(gctx));
-        v = LLVMBuildLoad(builder, lhsaddr, llvmgen_temp(gctx));
+        v = LLVMBuildLoad2(builder, lhstype, lhsaddr, llvmgen_temp(gctx));
         v = llvmgen_adjustval(gctx, v, lhstype, (accinfo.flags & LLVMGEN_M_SEG_SIGNEXT) != 0);
         v = LLVMBuildAnd(builder, v, dstmask, llvmgen_temp(gctx));
         v = LLVMBuildOr(builder, v, rhstemp, llvmgen_temp(gctx));
@@ -165,7 +165,7 @@ gen_fetch (gencodectx_t gctx, expr_node_t *rhs, LLVMTypeRef neededtype)
         val = llvmgen_adjustval(gctx, addr, type, signext);
     } else {
         addr = llvmgen_adjustval(gctx, addr, LLVMPointerType(type, 0), 0);
-        val = LLVMBuildLoad(builder, addr, llvmgen_temp(gctx));
+        val = LLVMBuildLoad2(builder, type, addr, llvmgen_temp(gctx));
         if ((accinfo.flags & LLVMGEN_M_SEG_VOLATILE) != 0) LLVMSetVolatile(val, 1);
     }
     if (shifts_required) {

--- a/lib/llvmgen/llvm_symgen.c
+++ b/lib/llvmgen/llvm_symgen.c
@@ -880,6 +880,28 @@ llvmgen_segaddress (gencodectx_t gctx, name_t *np, llvm_stgclass_t *segclassp, u
 } /* llvmgen_segaddress */
 
 /*
+ * llvmgen_rtntype_info
+ *
+ * Returns LLVM type info about a routine.
+ * Returns: function address
+ */
+LLVMValueRef
+llvmgen_rtntype_info (gencodectx_t gctx, name_t *np, LLVMTypeRef *func_type, LLVMTypeRef *return_type)
+{
+    lextype_t ntype = name_type(np);
+
+    if (ntype == LEXTYPE_NAME_ROUTINE) {
+        llvm_rtnsym_t *lr = sym_genspace(np);
+        if (func_type != 0) *func_type = lr->type;
+        if (return_type != 0) *return_type = lr->returntype;
+        return lr->func;
+    }
+    // Should never be called on any other name types
+    expr_signal(gctx->ectx, STC__INTCMPERR, "llvmgen_rtntype_info");
+    return 0;
+
+} /* llvmgen_rtntype_info */
+/*
  * symbol_gen_dispatch
  *
  * Dispatcher routine for generating a symbol.  Called

--- a/lib/llvmgen/llvmgen.h
+++ b/lib/llvmgen/llvmgen.h
@@ -209,6 +209,7 @@ LLVMValueRef llvmgen_segaddress(gencodectx_t gctx, name_t *np, llvm_stgclass_t *
                                 unsigned int *flagsp);
 LLVMValueRef llvmgen_expression(gencodectx_t gctx, expr_node_t *exp, LLVMTypeRef neededtype);
 LLVMValueRef llvmgen_addr_expression(gencodectx_t gctx, expr_node_t *exp, llvm_accinfo_t *accinfo);
+LLVMValueRef llvmgen_rtntype_info(gencodectx_t gctx, name_t *np, LLVMTypeRef *func_type, LLVMTypeRef *return_type);
 void llvmgen_deref_push(gencodectx_t gctx, name_t *np);
 void llvmgen_deref_pop(gencodectx_t gctx, name_t *np);
 void llvmgen_expgen_register(gencodectx_t gctx, exprtype_t type, llvmgen_expgen_fn func);

--- a/lib/llvmgen/llvmgen.h
+++ b/lib/llvmgen/llvmgen.h
@@ -206,7 +206,7 @@ void llvmgen_memcpy(gencodectx_t gctx, LLVMValueRef dest, LLVMValueRef src, LLVM
 void llvmgen_memset(gencodectx_t gctx, LLVMValueRef dest, LLVMValueRef val, LLVMValueRef len);
 LLVMValueRef llvmgen_assignment(gencodectx_t gctx, expr_node_t *lhs, expr_node_t *rhs);
 LLVMValueRef llvmgen_segaddress(gencodectx_t gctx, name_t *np, llvm_stgclass_t *segclass,
-                                unsigned int *flagsp);
+                                unsigned int *flagsp, LLVMTypeRef *llvm_type);
 LLVMValueRef llvmgen_expression(gencodectx_t gctx, expr_node_t *exp, LLVMTypeRef neededtype);
 LLVMValueRef llvmgen_addr_expression(gencodectx_t gctx, expr_node_t *exp, llvm_accinfo_t *accinfo);
 LLVMValueRef llvmgen_rtntype_info(gencodectx_t gctx, name_t *np, LLVMTypeRef *func_type, LLVMTypeRef *return_type);

--- a/lib/llvmgen/llvmgen.h
+++ b/lib/llvmgen/llvmgen.h
@@ -110,6 +110,7 @@ struct gencodectx_s {
     LLVMModuleRef       module;
     LLVMPassManagerRef  passmgr;
 
+    LLVMTypeRef         unittype;
     LLVMTypeRef         unitptrtype;
     LLVMTypeRef         fullwordtype;
     LLVMTypeRef         int1type;


### PR DESCRIPTION
* Migrate to the new API calls for [opaque pointers](https://llvm.org/docs/OpaquePointers.html), since the older APIs have been dropped in recent LLVM releases
* Handle the movement of the `TargetRegistry.h` header from `Support` to `MC`